### PR TITLE
Fix AWS client initialization and logging

### DIFF
--- a/kinesis/kinesis.py
+++ b/kinesis/kinesis.py
@@ -45,7 +45,7 @@ class KinesisStream:
                 )
         except ClientError as e:
             if "already exists" in e.response.get("Error").get("Message"):
-                logger.info("stream s% already exists", stream_name)
+                logger.info("stream %s already exists", stream_name)
             else:
                 raise
 
@@ -84,18 +84,17 @@ class KinesisStream:
         :return:
         """
         try:
-            return self.client.put_record(
+            response = self.client.put_record(
                 StreamName=stream_name,
                 Data=json.dumps(data),
                 PartitionKey=partition_key
             )
             logger.info("Put record in stream")
+            return response
 
         except ClientError:
             logger.exception("Couldn't put record in stream %s", stream_name)
             raise
-        else:
-            return response
 
     def put_records(self, stream_name: str, data: list[dict], partition_key: str):
         try:

--- a/s3/__init__.py
+++ b/s3/__init__.py
@@ -1,5 +1,6 @@
 from s3.s3 import s3_client
 
 __all__ = [
-    s3_client
+    "s3_client",
 ]
+

--- a/s3/s3.py
+++ b/s3/s3.py
@@ -10,7 +10,8 @@ profile_name = os.environ.get("PROFILE_NAME", "sandbox")
 
 
 def create_s3_client(profile_name):
-    return boto3.Session(profile_name=profile_name).client('kinesis')
+    """Create a boto3 S3 client using the configured AWS profile."""
+    return boto3.Session(profile_name=profile_name).client('s3')
 
 
 class S3:


### PR DESCRIPTION
## Summary
- fix `create_s3_client` to return an S3 client instead of a Kinesis client
- correct `__all__` in `s3/__init__.py`
- fix logging message and put_record logic in KinesisStream

## Testing
- `make tests` *(fails: venv missing)*
- `python -m unittest discover` *(fails: boto profile not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405354c184832bb09588ec3b5b6e87