### PR TITLE
Add S3 bucket creation tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ install:
 
 build: venv install
 
-
+.PHONY: tests
 tests:
-	venv/bin/python -m unittest discover -s src -p '*_test.py'
+	venv/bin/python -m unittest discover -s tests -p '*_test.py'
 
 clean:
 	rm -rf venv

--- a/tests/s3_test.py
+++ b/tests/s3_test.py
@@ -1,0 +1,48 @@
+import importlib
+import unittest
+from unittest.mock import MagicMock, patch
+from botocore.exceptions import ClientError
+
+# Patch boto3.Session before importing the module so that module-level code
+# does not try to load AWS configuration.
+with patch('boto3.Session') as mock_session:
+    mock_session.return_value.client.return_value = MagicMock()
+    s3_module = importlib.import_module('s3.s3')
+
+S3 = s3_module.S3
+
+
+class TestCreateBucketIfNotExist(unittest.TestCase):
+    @patch('s3.s3.create_s3_client')
+    def test_create_bucket_success(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        s3_instance = S3()
+        result = s3_instance.create_bucket_if_not_exist('mybucket')
+
+        mock_client.create_bucket.assert_called_once_with(Bucket='mybucket')
+        self.assertTrue(result)
+
+    @patch('s3.s3.create_s3_client')
+    def test_create_bucket_already_owned(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        error_response = {
+            'Error': {
+                'Code': 'BucketAlreadyOwnedByYou',
+                'Message': 'Bucket already exists'
+            }
+        }
+        mock_client.create_bucket.side_effect = ClientError(error_response, 'CreateBucket')
+
+        s3_instance = S3()
+        result = s3_instance.create_bucket_if_not_exist('existingbucket')
+
+        mock_client.create_bucket.assert_called_once_with(Bucket='existingbucket')
+        self.assertTrue(result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests directory with unit tests for S3.create_bucket_if_not_exist
- update Makefile to discover tests from tests/

## Testing
- `python3 -m unittest discover -s tests -p '*_test.py'`

------
https://chatgpt.com/codex/tasks/task_e_68405aff4e44832b91b2277b5434dba2