### PR TITLE
Add export_metadata script for AWS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # Data engineer toolkit
+
+This repository provides utilities for interacting with AWS services.
+
+## Scripts
+
+- `scripts/kinesis_cli.py` - example of writing records to Kinesis.
+- `scripts/export_metadata.py` - extract metadata from AWS services and store it in a local DuckDB database.

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ traitlets==5.3.0
 urllib3==1.26.10
 wcwidth==0.2.5
 mimesis==5.5.0
+duckdb>=0.10.0
+pandas>=1.0.0
+

--- a/scripts/export_metadata.py
+++ b/scripts/export_metadata.py
@@ -1,0 +1,75 @@
+import argparse
+import os
+from typing import Iterable
+
+import boto3
+import duckdb
+import pandas as pd
+
+profile_name = os.environ.get("PROFILE_NAME", "sandbox")
+
+
+def create_client(service_name: str):
+    return boto3.Session(profile_name=profile_name).client(service_name)
+
+
+def list_s3_objects(bucket: str, prefix: str = "") -> Iterable[dict]:
+    client = create_client("s3")
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            yield {
+                "key": obj.get("Key"),
+                "last_modified": obj.get("LastModified"),
+                "size": obj.get("Size"),
+                "storage_class": obj.get("StorageClass"),
+            }
+
+
+def list_athena_tables(catalog: str, database: str) -> Iterable[dict]:
+    client = create_client("athena")
+    paginator = client.get_paginator("list_table_metadata")
+    for page in paginator.paginate(CatalogName=catalog, DatabaseName=database):
+        for meta in page.get("TableMetadataList", []):
+            yield {
+                "name": meta.get("Name"),
+                "create_time": meta.get("CreateTime"),
+                "last_access_time": meta.get("LastAccessTime"),
+                "table_type": meta.get("TableType"),
+            }
+
+
+def save_to_duckdb(rows: Iterable[dict], table_name: str, db_path: str) -> None:
+    con = duckdb.connect(db_path)
+    df = pd.DataFrame(rows)
+    con.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM df")
+    con.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Export AWS metadata to DuckDB")
+    subparsers = parser.add_subparsers(dest="command")
+
+    s3_parser = subparsers.add_parser("s3")
+    s3_parser.add_argument("--bucket", required=True)
+    s3_parser.add_argument("--prefix", default="")
+    s3_parser.add_argument("--db-path", default="aws_metadata.duckdb")
+    s3_parser.add_argument("--table", default="s3_objects")
+
+    athena_parser = subparsers.add_parser("athena")
+    athena_parser.add_argument("--catalog", required=True)
+    athena_parser.add_argument("--database", required=True)
+    athena_parser.add_argument("--db-path", default="aws_metadata.duckdb")
+    athena_parser.add_argument("--table", default="athena_tables")
+
+    args = parser.parse_args()
+
+    if args.command == "s3":
+        items = list(list_s3_objects(args.bucket, args.prefix))
+        save_to_duckdb(items, args.table, args.db_path)
+    elif args.command == "athena":
+        items = list(list_athena_tables(args.catalog, args.database))
+        save_to_duckdb(items, args.table, args.db_path)
+    else:
+        parser.print_help()
+


### PR DESCRIPTION
## Summary
- add `export_metadata.py` script to fetch AWS metadata and store it in DuckDB
- document new script in README
- add duckdb and pandas as requirements

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover` *(fails: ProfileNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_684056d6eeac832bb4012f8762beb462