### PR TITLE
Fix docstring typo in KinesisStream

### DIFF
--- a/kinesis/kinesis.py
+++ b/kinesis/kinesis.py
@@ -51,7 +51,7 @@ class KinesisStream:
 
     def describe(self, stream_name):
         """
-        Describre stream
+        Describe stream
         :param stream_name:
         :return:
         """


### PR DESCRIPTION
## Summary
- fix a typo in `kinesis/kinesis.py`

## Testing
- `python -m unittest discover -s tests -p '*_test.py'`

------
https://chatgpt.com/codex/tasks/task_e_684079c76198832bb4e91d66c179cd66