### PR TITLE
Fix create_s3_client service

### DIFF
--- a/s3/s3.py
+++ b/s3/s3.py
@@ -11,7 +11,8 @@ profile_name = os.environ.get("PROFILE_NAME", "sandbox")
 
 def create_s3_client(profile_name):
     """Create a boto3 S3 client using the configured AWS profile."""
-    return boto3.Session(profile_name=profile_name).client('s3')
+    session = boto3.Session(profile_name=profile_name)
+    return session.client('s3')
 
 
 class S3:


### PR DESCRIPTION
## Summary
- use boto3 session to return an S3 client

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684079c477d0832b8e292e9725b64ade