### PR TITLE
Add Sagemaker metadata export

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This repository provides utilities for interacting with AWS services.
 
 - test
 - `scripts/kinesis_cli.py` - example of writing records to Kinesis.
-- `scripts/export_metadata.py` - extract metadata from AWS services and store it in a local DuckDB database.
+- `scripts/export_metadata.py` - extract metadata from AWS services and store it in a local DuckDB database. Supported resources include S3 objects, Athena tables and errors, Glue jobs and runs, and Sagemaker pipelines, training, and processing jobs.


### PR DESCRIPTION
## Summary
- extend export_metadata script to include Sagemaker pipelines, training, and processing jobs
- update README with newly supported resources

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684117767838832b96f25dde4ad15502