### PR TITLE
Add CloudFormation stack listing with filtering capabilities

### DIFF
--- a/cli/list_cloudformation.py
+++ b/cli/list_cloudformation.py
@@ -1,0 +1,173 @@
+"""List CloudFormation stacks with filtering options."""
+import re
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import click
+
+from cli.base import apply_limit, common_options, format_output
+from cloudformation.cloudformation import create_cloudformation_client
+
+
+def list_cloudformation_stacks(
+    name_prefix: Optional[str] = None,
+    tag_filters: Optional[dict[str, str]] = None,
+    name_regex: Optional[str] = None,
+    stack_status_filter: Optional[list[str]] = None,
+    profile: Optional[str] = None,
+    verbose: bool = False
+) -> Iterator[dict[str, Any]]:
+    """List CloudFormation stacks with filtering."""
+    client = create_cloudformation_client(profile_name=profile or "sandbox")
+
+    # Build pagination parameters
+    params = {}
+    if stack_status_filter:
+        params["StackStatusFilter"] = stack_status_filter
+
+    paginator = client.get_paginator("list_stacks")
+    page_iterator = paginator.paginate(**params)
+
+    # Compile regex pattern if provided
+    regex_pattern = re.compile(name_regex) if name_regex else None
+
+    for page in page_iterator:
+        for stack in page.get("StackSummaries", []):
+            stack_name = stack.get("StackName", "")
+
+            # Apply name prefix filter
+            if name_prefix and not stack_name.startswith(name_prefix):
+                continue
+
+            # Apply regex filter
+            if regex_pattern and not regex_pattern.search(stack_name):
+                continue
+
+            # Apply tag filters if specified
+            if tag_filters and not _match_tags(client, stack_name, tag_filters):
+                continue
+
+            result = {
+                "stack_name": stack_name,
+                "stack_id": stack.get("StackId"),
+                "creation_time": stack.get("CreationTime").isoformat() if stack.get("CreationTime") else None,
+                "last_updated_time": stack.get("LastUpdatedTime").isoformat() if stack.get("LastUpdatedTime") else None,
+                "stack_status": stack.get("StackStatus"),
+                "template_description": stack.get("TemplateDescription"),
+            }
+
+            if verbose:
+                result.update({
+                    "deletion_time": stack.get("DeletionTime").isoformat() if stack.get("DeletionTime") else None,
+                    "stack_status_reason": stack.get("StackStatusReason"),
+                    "drift_information": stack.get("DriftInformation"),
+                })
+
+            yield result
+
+
+def _match_tags(client, stack_name: str, tag_filters: dict[str, str]) -> bool:
+    """Check if a stack matches the specified tag filters."""
+    try:
+        response = client.describe_stacks(StackName=stack_name)
+        stacks = response.get("Stacks", [])
+
+        if not stacks:
+            return False
+
+        stack_tags = stacks[0].get("Tags", [])
+        stack_tag_dict = {tag["Key"]: tag["Value"] for tag in stack_tags}
+
+        # Check if all tag filters match
+        for key, value in tag_filters.items():
+            if key not in stack_tag_dict or stack_tag_dict[key] != value:
+                return False
+
+        return True
+
+    except Exception:
+        return False
+
+
+def parse_tag_filters(tag_string: str) -> dict[str, str]:
+    """Parse tag filter string like 'Environment=prod,Team=backend' into dict."""
+    if not tag_string:
+        return {}
+
+    tags = {}
+    for pair in tag_string.split(','):
+        if '=' in pair:
+            key, value = pair.split('=', 1)
+            tags[key.strip()] = value.strip()
+
+    return tags
+
+
+def parse_status_filters(status_string: str) -> list[str]:
+    """Parse status filter string like 'CREATE_COMPLETE,UPDATE_COMPLETE' into list."""
+    if not status_string:
+        return []
+
+    return [status.strip() for status in status_string.split(',')]
+
+
+@click.command('aws-list-cloudformation-stacks')
+@click.option('--name-prefix', '-p', help='Filter stacks by name prefix')
+@click.option('--name-regex', '-r', help='Filter stacks by name regex pattern')
+@click.option('--tags', '-t', help='Filter by tags (format: key1=value1,key2=value2)')
+@click.option('--status', '-s', help='Filter by stack status (comma-separated)')
+@common_options
+def cli(name_prefix, name_regex, tags, status, profile, region, output_format,
+        limit, output_fields, no_header, verbose):
+    """List CloudFormation stacks with filtering options.
+
+    Examples:
+
+        # List all stacks
+        aws-list-cloudformation-stacks
+
+        # Filter by name prefix
+        aws-list-cloudformation-stacks --name-prefix my-app
+
+        # Filter by regex pattern
+        aws-list-cloudformation-stacks --name-regex ".*-prod-.*"
+
+        # Filter by tags
+        aws-list-cloudformation-stacks --tags "Environment=production,Team=backend"
+
+        # Filter by status
+        aws-list-cloudformation-stacks --status "CREATE_COMPLETE,UPDATE_COMPLETE"
+
+        # Combine filters
+        aws-list-cloudformation-stacks --name-prefix app --tags "Environment=prod" --status "CREATE_COMPLETE"
+
+        # Output as CSV with specific fields
+        aws-list-cloudformation-stacks --format csv --output-fields stack_name,stack_status,creation_time
+
+        # Get verbose output with all details
+        aws-list-cloudformation-stacks --verbose
+    """
+    _ = region  # Suppress unused parameter warning
+
+    # Parse filters
+    tag_filters = parse_tag_filters(tags) if tags else None
+    status_filters = parse_status_filters(status) if status else None
+
+    # Get stacks
+    stacks = list_cloudformation_stacks(
+        name_prefix=name_prefix,
+        tag_filters=tag_filters,
+        name_regex=name_regex,
+        stack_status_filter=status_filters,
+        profile=profile,
+        verbose=verbose
+    )
+
+    # Apply limit and format output
+    limited_stacks = apply_limit(stacks, limit)
+    format_output(limited_stacks, output_format, output_fields, no_header)
+
+
+if __name__ == '__main__':
+    cli()
+

--- a/cloudformation/cloudformation.py
+++ b/cloudformation/cloudformation.py
@@ -1,0 +1,185 @@
+import logging
+import os
+import re
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+profile_name = os.environ.get("PROFILE_NAME", "sandbox")
+
+
+def create_cloudformation_client(profile_name: str) -> Any:
+    """Create a boto3 CloudFormation client using the configured AWS profile."""
+    session = boto3.Session(profile_name=profile_name)
+    return session.client("cloudformation")
+
+
+class CloudFormation:
+    def __init__(self):
+        self.client = create_cloudformation_client(profile_name)
+
+    def list_stacks(
+        self,
+        name_prefix: Optional[str] = None,
+        tag_filters: Optional[dict[str, str]] = None,
+        name_regex: Optional[str] = None,
+        stack_status_filter: Optional[list[str]] = None,
+    ) -> Iterator[dict[str, Any]]:
+        """
+        List CloudFormation stacks with filtering options.
+        :param name_prefix: Filter stacks by name prefix
+        :param tag_filters: Filter stacks by tags (key-value pairs)
+        :param name_regex: Filter stacks by name using regex pattern
+        :param stack_status_filter: Filter by stack status
+        :return: Iterator of stack dictionaries
+        """
+        try:
+            paginator = self.client.get_paginator("list_stacks")
+
+            # Build pagination parameters
+            params = {}
+            if stack_status_filter:
+                params["StackStatusFilter"] = stack_status_filter
+
+            page_iterator = paginator.paginate(**params)
+
+            # Compile regex pattern if provided
+            regex_pattern = re.compile(name_regex) if name_regex else None
+
+            for page in page_iterator:
+                for stack in page.get("StackSummaries", []):
+                    stack_name = stack.get("StackName", "")
+
+                    # Apply name prefix filter
+                    if name_prefix and not stack_name.startswith(name_prefix):
+                        continue
+
+                    # Apply regex filter
+                    if regex_pattern and not regex_pattern.search(stack_name):
+                        continue
+
+                    # Apply tag filters if specified
+                    if tag_filters and not self._match_tags(stack_name, tag_filters):
+                        continue
+
+                    yield {
+                        "stack_name": stack_name,
+                        "stack_id": stack.get("StackId"),
+                        "creation_time": stack.get("CreationTime"),
+                        "last_updated_time": stack.get("LastUpdatedTime"),
+                        "deletion_time": stack.get("DeletionTime"),
+                        "stack_status": stack.get("StackStatus"),
+                        "stack_status_reason": stack.get("StackStatusReason"),
+                        "template_description": stack.get("TemplateDescription"),
+                        "drift_information": stack.get("DriftInformation"),
+                    }
+
+        except ClientError as e:
+            logger.error(f"Error listing CloudFormation stacks: {e}")
+            raise
+
+    def _match_tags(self, stack_name: str, tag_filters: dict[str, str]) -> bool:
+        """
+        Check if a stack matches the specified tag filters.
+
+        :param stack_name: Name of the stack
+        :param tag_filters: Dictionary of tag key-value pairs to match
+        :return: True if stack matches all tag filters, False otherwise
+        """
+        try:
+            response = self.client.describe_stacks(StackName=stack_name)
+            stacks = response.get("Stacks", [])
+
+            if not stacks:
+                return False
+
+            stack_tags = stacks[0].get("Tags", [])
+            stack_tag_dict = {tag["Key"]: tag["Value"] for tag in stack_tags}
+
+            # Check if all tag filters match
+            for key, value in tag_filters.items():
+                if key not in stack_tag_dict or stack_tag_dict[key] != value:
+                    return False
+
+            return True
+
+        except ClientError as e:
+            logger.warning(f"Error getting tags for stack {stack_name}: {e}")
+            return False
+
+    def get_stack_details(self, stack_name: str) -> dict[str, Any]:
+        """
+        Get detailed information about a specific stack.
+
+        :param stack_name: Name or ID of the stack
+        :return: Dictionary with stack details
+        """
+        try:
+            response = self.client.describe_stacks(StackName=stack_name)
+            stacks = response.get("Stacks", [])
+
+            if not stacks:
+                raise ValueError(f"Stack {stack_name} not found")
+
+            stack = stacks[0]
+            return {
+                "stack_name": stack.get("StackName"),
+                "stack_id": stack.get("StackId"),
+                "description": stack.get("Description"),
+                "parameters": stack.get("Parameters", []),
+                "creation_time": stack.get("CreationTime"),
+                "last_updated_time": stack.get("LastUpdatedTime"),
+                "stack_status": stack.get("StackStatus"),
+                "stack_status_reason": stack.get("StackStatusReason"),
+                "disable_rollback": stack.get("DisableRollback"),
+                "notification_arns": stack.get("NotificationARNs", []),
+                "timeout_in_minutes": stack.get("TimeoutInMinutes"),
+                "capabilities": stack.get("Capabilities", []),
+                "outputs": stack.get("Outputs", []),
+                "role_arn": stack.get("RoleARN"),
+                "tags": stack.get("Tags", []),
+                "enable_termination_protection": stack.get("EnableTerminationProtection"),
+                "parent_id": stack.get("ParentId"),
+                "root_id": stack.get("RootId"),
+                "drift_information": stack.get("DriftInformation"),
+            }
+
+        except ClientError as e:
+            logger.error(f"Error getting stack details for {stack_name}: {e}")
+            raise
+
+    def list_stack_resources(self, stack_name: str) -> Iterator[dict[str, Any]]:
+        """
+        List resources in a CloudFormation stack.
+
+        :param stack_name: Name or ID of the stack
+        :return: Iterator of resource dictionaries
+        """
+        try:
+            paginator = self.client.get_paginator("list_stack_resources")
+            page_iterator = paginator.paginate(StackName=stack_name)
+
+            for page in page_iterator:
+                for resource in page.get("StackResourceSummaries", []):
+                    yield {
+                        "logical_resource_id": resource.get("LogicalResourceId"),
+                        "physical_resource_id": resource.get("PhysicalResourceId"),
+                        "resource_type": resource.get("ResourceType"),
+                        "last_updated_timestamp": resource.get("LastUpdatedTimestamp"),
+                        "resource_status": resource.get("ResourceStatus"),
+                        "resource_status_reason": resource.get("ResourceStatusReason"),
+                        "drift_information": resource.get("DriftInformation"),
+                        "module_info": resource.get("ModuleInfo"),
+                    }
+
+        except ClientError as e:
+            logger.error(f"Error listing resources for stack {stack_name}: {e}")
+            raise
+
+
+cloudformation_client = CloudFormation()
+

--- a/tests/cloudformation_test.py
+++ b/tests/cloudformation_test.py
@@ -1,0 +1,282 @@
+import importlib
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+# Patch boto3.Session before importing the module so that module-level code
+# does not try to load AWS configuration.
+with patch("boto3.Session") as mock_session:
+    mock_session.return_value.client.return_value = MagicMock()
+    cf_module = importlib.import_module("cloudformation.cloudformation")
+
+CloudFormation = cf_module.CloudFormation
+
+
+class TestCloudFormationListStacks(unittest.TestCase):
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_list_stacks_success(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock paginator response
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+
+        mock_page = {
+            "StackSummaries": [
+                {
+                    "StackName": "test-stack-1",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack-1/uuid",
+                    "CreationTime": datetime(2024, 1, 1, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                    "TemplateDescription": "Test stack 1"
+                },
+                {
+                    "StackName": "test-stack-2",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack-2/uuid",
+                    "CreationTime": datetime(2024, 1, 2, 12, 0, 0),
+                    "StackStatus": "UPDATE_COMPLETE",
+                    "TemplateDescription": "Test stack 2"
+                }
+            ]
+        }
+        mock_paginator.paginate.return_value = [mock_page]
+
+        cf_instance = CloudFormation()
+        stacks = list(cf_instance.list_stacks())
+
+        self.assertEqual(len(stacks), 2)
+        self.assertEqual(stacks[0]["stack_name"], "test-stack-1")
+        self.assertEqual(stacks[1]["stack_name"], "test-stack-2")
+        mock_client.get_paginator.assert_called_once_with("list_stacks")
+
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_list_stacks_with_name_prefix_filter(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock paginator response
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+
+        mock_page = {
+            "StackSummaries": [
+                {
+                    "StackName": "app-prod-stack",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/app-prod-stack/uuid",
+                    "CreationTime": datetime(2024, 1, 1, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                },
+                {
+                    "StackName": "database-stack",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/database-stack/uuid",
+                    "CreationTime": datetime(2024, 1, 2, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                }
+            ]
+        }
+        mock_paginator.paginate.return_value = [mock_page]
+
+        cf_instance = CloudFormation()
+        stacks = list(cf_instance.list_stacks(name_prefix="app-"))
+
+        self.assertEqual(len(stacks), 1)
+        self.assertEqual(stacks[0]["stack_name"], "app-prod-stack")
+
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_list_stacks_with_regex_filter(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock paginator response
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+
+        mock_page = {
+            "StackSummaries": [
+                {
+                    "StackName": "app-prod-stack",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/app-prod-stack/uuid",
+                    "CreationTime": datetime(2024, 1, 1, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                },
+                {
+                    "StackName": "app-dev-stack",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/app-dev-stack/uuid",
+                    "CreationTime": datetime(2024, 1, 2, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                },
+                {
+                    "StackName": "database-stack",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/database-stack/uuid",
+                    "CreationTime": datetime(2024, 1, 3, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                }
+            ]
+        }
+        mock_paginator.paginate.return_value = [mock_page]
+
+        cf_instance = CloudFormation()
+        stacks = list(cf_instance.list_stacks(name_regex=r".*-prod-.*"))
+
+        self.assertEqual(len(stacks), 1)
+        self.assertEqual(stacks[0]["stack_name"], "app-prod-stack")
+
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_list_stacks_with_status_filter(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock paginator response
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+
+        mock_page = {
+            "StackSummaries": [
+                {
+                    "StackName": "test-stack-1",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack-1/uuid",
+                    "CreationTime": datetime(2024, 1, 1, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                }
+            ]
+        }
+        mock_paginator.paginate.return_value = [mock_page]
+
+        cf_instance = CloudFormation()
+        stacks = list(cf_instance.list_stacks(stack_status_filter=["CREATE_COMPLETE"]))
+
+        self.assertEqual(len(stacks), 1)
+        mock_paginator.paginate.assert_called_once_with(StackStatusFilter=["CREATE_COMPLETE"])
+
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_list_stacks_with_tag_filter(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock paginator response
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+
+        mock_page = {
+            "StackSummaries": [
+                {
+                    "StackName": "test-stack-1",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack-1/uuid",
+                    "CreationTime": datetime(2024, 1, 1, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                }
+            ]
+        }
+        mock_paginator.paginate.return_value = [mock_page]
+
+        # Mock describe_stacks response for tag matching
+        mock_client.describe_stacks.return_value = {
+            "Stacks": [
+                {
+                    "Tags": [
+                        {"Key": "Environment", "Value": "production"},
+                        {"Key": "Team", "Value": "backend"}
+                    ]
+                }
+            ]
+        }
+
+        cf_instance = CloudFormation()
+        stacks = list(cf_instance.list_stacks(tag_filters={"Environment": "production"}))
+
+        self.assertEqual(len(stacks), 1)
+        mock_client.describe_stacks.assert_called_once_with(StackName="test-stack-1")
+
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_get_stack_details_success(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_client.describe_stacks.return_value = {
+            "Stacks": [
+                {
+                    "StackName": "test-stack",
+                    "StackId": "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/uuid",
+                    "Description": "Test stack description",
+                    "CreationTime": datetime(2024, 1, 1, 12, 0, 0),
+                    "StackStatus": "CREATE_COMPLETE",
+                    "Parameters": [{"ParameterKey": "Environment", "ParameterValue": "prod"}],
+                    "Tags": [{"Key": "Team", "Value": "backend"}],
+                    "Outputs": [{"OutputKey": "WebsiteURL", "OutputValue": "https://example.com"}]
+                }
+            ]
+        }
+
+        cf_instance = CloudFormation()
+        details = cf_instance.get_stack_details("test-stack")
+
+        self.assertEqual(details["stack_name"], "test-stack")
+        self.assertEqual(details["description"], "Test stack description")
+        self.assertEqual(len(details["parameters"]), 1)
+        self.assertEqual(len(details["tags"]), 1)
+        mock_client.describe_stacks.assert_called_once_with(StackName="test-stack")
+
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_get_stack_details_not_found(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        mock_client.describe_stacks.return_value = {"Stacks": []}
+
+        cf_instance = CloudFormation()
+
+        with self.assertRaises(ValueError) as context:
+            cf_instance.get_stack_details("nonexistent-stack")
+
+        self.assertIn("Stack nonexistent-stack not found", str(context.exception))
+
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_list_stack_resources_success(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        # Mock paginator response
+        mock_paginator = MagicMock()
+        mock_client.get_paginator.return_value = mock_paginator
+
+        mock_page = {
+            "StackResourceSummaries": [
+                {
+                    "LogicalResourceId": "WebServerInstance",
+                    "PhysicalResourceId": "i-1234567890abcdef0",
+                    "ResourceType": "AWS::EC2::Instance",
+                    "ResourceStatus": "CREATE_COMPLETE",
+                    "LastUpdatedTimestamp": datetime(2024, 1, 1, 12, 0, 0)
+                }
+            ]
+        }
+        mock_paginator.paginate.return_value = [mock_page]
+
+        cf_instance = CloudFormation()
+        resources = list(cf_instance.list_stack_resources("test-stack"))
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["logical_resource_id"], "WebServerInstance")
+        self.assertEqual(resources[0]["resource_type"], "AWS::EC2::Instance")
+        mock_client.get_paginator.assert_called_once_with("list_stack_resources")
+        mock_paginator.paginate.assert_called_once_with(StackName="test-stack")
+
+    @patch("cloudformation.cloudformation.create_cloudformation_client")
+    def test_list_stacks_client_error(self, mock_create_client):
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        error_response = {"Error": {"Code": "AccessDenied", "Message": "User not authorized"}}
+        mock_client.get_paginator.side_effect = ClientError(error_response, "ListStacks")
+
+        cf_instance = CloudFormation()
+
+        with self.assertRaises(ClientError):
+            list(cf_instance.list_stacks())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- ✅ CloudFormation module with comprehensive stack operations
- ✅ CLI tool for listing stacks with multiple filtering options
- ✅ Export script integration for local data lake
- ✅ Comprehensive test coverage

## Features
- **Name prefix filtering**: `--name-prefix my-app`  
- **Regex pattern matching**: `--name-regex ".*-prod-.*"`
- **Tag-based filtering**: `--tags "Environment=production,Team=backend"`
- **Stack status filtering**: `--status "CREATE_COMPLETE,UPDATE_COMPLETE"`
- **JSON/CSV output formats** with field selection
- **Export to DuckDB** for data analysis

## Test plan
- [x] Unit tests with mocked AWS API calls
- [x] All linting checks pass
- [x] Follows existing codebase patterns
- [x] CLI help documentation and examples
- [x] Integration with export metadata script

## Usage Examples
```bash
# List all stacks
aws-list-cloudformation-stacks

# Filter by name prefix  
aws-list-cloudformation-stacks --name-prefix my-app

# Filter by regex pattern
aws-list-cloudformation-stacks --name-regex ".*-prod-.*" 

# Filter by tags
aws-list-cloudformation-stacks --tags "Environment=production,Team=backend"

# Export to DuckDB
python scripts/export_metadata.py cloudformation --name-prefix my-app --days 30
```